### PR TITLE
12.0+ compat: guard secret-value taint + toc 120005

### DIFF
--- a/DataStore_Stats/DataStore_Stats.lua
+++ b/DataStore_Stats/DataStore_Stats.lua
@@ -15,9 +15,16 @@ local UnitRangedDamage, UnitRangedAttackPower, GetRangedCritChance, GetDodgeChan
 
 local C_ChallengeMode, C_MythicPlus, C_WeeklyRewards = C_ChallengeMode, C_MythicPlus, C_WeeklyRewards
 
--- In WoW 12.0+ some Unit*/Get* APIs may return secret values that taint
--- table.concat (the internal tostring fails). Wrap the concat so the scan
--- degrades gracefully instead of erroring out the whole AddonFactory callback.
+-- In WoW 12.0+ many Unit*/Get* stat APIs return secret values whose internal
+-- tostring / arithmetic raises ("invalid value (secret) ..." or "attempt to
+-- perform numeric conversion on a secret number value"). Run each section in
+-- a pcall so a single tainted block doesn't abort the whole AddonFactory
+-- callback - the previously stored value is kept on failure.
+local function SafePcall(fn)
+	local ok, err = pcall(fn)
+	-- swallow err; previously stored fields keep their last good value
+end
+
 local function SafeConcat(t, sep)
 	local ok, result = pcall(TableConcat, t, sep)
 	return ok and result or nil
@@ -30,70 +37,85 @@ end
 
 local function ScanStats()
 	local char = thisCharacter
-	
-	char.HealthMax = UnitHealthMax("player")
+
+	SafePcall(function()
+		char.HealthMax = UnitHealthMax("player")
+	end)
 	-- info on power types here : http://www.wowwiki.com/API_UnitPowerType
-	char.MaxPower = format("%d|%d", UnitPowerType("player"), UnitPowerMax("player"))
-	
+	SafePcall(function()
+		char.MaxPower = format("%d|%d", UnitPowerType("player"), UnitPowerMax("player"))
+	end)
+
 	local t = {}
 
 	-- *** Base ***
 	--	"strength | agility | stamina | intellect | spirit | armor"
-	for i = 1, 4 do
-		t[i] = UnitStat("player", i)
-		-- stat, effectiveStat, posBuff, negBuff = UnitStat("player", statIndex);
-	end
-	t[5] = UnitArmor("player")
-	char.Base = SafeConcat(t, "|") or char.Base
-	
+	SafePcall(function()
+		for i = 1, 4 do
+			t[i] = UnitStat("player", i)
+			-- stat, effectiveStat, posBuff, negBuff = UnitStat("player", statIndex);
+		end
+		t[5] = UnitArmor("player")
+		char.Base = SafeConcat(t, "|") or char.Base
+	end)
+
 	-- *** Melee ***
 	--	"Damage | Speed | Power | Hit rating | Crit chance | Expertise"
-	local minDmg, maxDmg = UnitDamage("player")
-	t[1] = format("%d-%d", floor(minDmg), ceil(maxDmg))	-- Damage "215-337"
-	t[2] = format("%.2f", UnitAttackSpeed("player"))
-	t[3] = UnitAttackPower("player")
-	t[4] = GetCombatRating(CR_HIT_MELEE)
-	t[5] = format("%.2f", GetCritChance())
-	t[6] = GetExpertise()
-	char.Melee = SafeConcat(t, "|") or char.Melee
-	
+	SafePcall(function()
+		local minDmg, maxDmg = UnitDamage("player")
+		t[1] = format("%d-%d", floor(minDmg), ceil(maxDmg))	-- Damage "215-337"
+		t[2] = format("%.2f", UnitAttackSpeed("player"))
+		t[3] = UnitAttackPower("player")
+		t[4] = GetCombatRating(CR_HIT_MELEE)
+		t[5] = format("%.2f", GetCritChance())
+		t[6] = GetExpertise()
+		char.Melee = SafeConcat(t, "|") or char.Melee
+	end)
+
 	-- *** Ranged ***
 	--	"Damage | Speed | Power | Hit rating | Crit chance"
-	local speed
-	speed, minDmg, maxDmg = UnitRangedDamage("player")
-	t[1] = format("%d-%d", floor(minDmg), ceil(maxDmg))
-	t[2] = speed
-	t[3] = UnitRangedAttackPower("player")
-	t[4] = GetCombatRating(CR_HIT_RANGED)
-	t[5] = format("%.2f", GetRangedCritChance())
-	t[6] = nil
-	char.Ranged = SafeConcat(t, "|") or char.Ranged
-	
+	SafePcall(function()
+		local speed, minDmg, maxDmg = UnitRangedDamage("player")
+		t[1] = format("%d-%d", floor(minDmg), ceil(maxDmg))
+		t[2] = speed
+		t[3] = UnitRangedAttackPower("player")
+		t[4] = GetCombatRating(CR_HIT_RANGED)
+		t[5] = format("%.2f", GetRangedCritChance())
+		t[6] = nil
+		char.Ranged = SafeConcat(t, "|") or char.Ranged
+	end)
+
 	-- *** Spell ***
 	--	"+Damage | +Healing | Hit | Crit chance | Haste | Mana Regen"
-	t[1] = GetSpellBonusDamage(2)			-- 2, since 1 = physical damage
-	t[2] = GetSpellBonusHealing()
-	t[3] = GetCombatRating(CR_HIT_SPELL)
-	t[4] = format("%.2f", GetSpellCritChance(2))
-	t[5] = GetCombatRating(CR_HASTE_SPELL)
-	t[6] = floor(GetManaRegen() * 5.0)
-	char.Spell = SafeConcat(t, "|") or char.Spell
-		
+	SafePcall(function()
+		t[1] = GetSpellBonusDamage(2)			-- 2, since 1 = physical damage
+		t[2] = GetSpellBonusHealing()
+		t[3] = GetCombatRating(CR_HIT_SPELL)
+		t[4] = format("%.2f", GetSpellCritChance(2))
+		t[5] = GetCombatRating(CR_HASTE_SPELL)
+		t[6] = floor(GetManaRegen() * 5.0)
+		char.Spell = SafeConcat(t, "|") or char.Spell
+	end)
+
 	-- *** Defense ***
 	--	"Armor | Defense | Dodge | Parry | Block | Resilience"
-	t[1] = UnitArmor("player")
-	t[2] = 0		-- UnitDefense("player")	deprecated in 8.0
-	t[3] = GetDodgeChance()
-	t[4] = format("%.2f", GetParryChance())
-	t[5] = format("%.2f", GetBlockChance())
-	t[6] = GetCombatRating(COMBAT_RATING_RESILIENCE_PLAYER_DAMAGE_TAKEN)
-	char.Defense = SafeConcat(t, "|") or char.Defense
+	SafePcall(function()
+		t[1] = UnitArmor("player")
+		t[2] = 0		-- UnitDefense("player")	deprecated in 8.0
+		t[3] = GetDodgeChance()
+		t[4] = format("%.2f", GetParryChance())
+		t[5] = format("%.2f", GetBlockChance())
+		t[6] = GetCombatRating(COMBAT_RATING_RESILIENCE_PLAYER_DAMAGE_TAKEN)
+		char.Defense = SafeConcat(t, "|") or char.Defense
+	end)
 
 	-- *** PVP ***
 	--	"honorable kills | dishonorable kills"
-	wipe(t)
-	t[1], t[2] = GetPVPLifetimeStats()
-	char.PVP = SafeConcat(t, "|") or char.PVP
+	SafePcall(function()
+		wipe(t)
+		t[1], t[2] = GetPVPLifetimeStats()
+		char.PVP = SafeConcat(t, "|") or char.PVP
+	end)
 	
 	-- *** Arena Teams ***
 	--[[

--- a/DataStore_Stats/DataStore_Stats.lua
+++ b/DataStore_Stats/DataStore_Stats.lua
@@ -15,6 +15,14 @@ local UnitRangedDamage, UnitRangedAttackPower, GetRangedCritChance, GetDodgeChan
 
 local C_ChallengeMode, C_MythicPlus, C_WeeklyRewards = C_ChallengeMode, C_MythicPlus, C_WeeklyRewards
 
+-- In WoW 12.0+ some Unit*/Get* APIs may return secret values that taint
+-- table.concat (the internal tostring fails). Wrap the concat so the scan
+-- degrades gracefully instead of erroring out the whole AddonFactory callback.
+local function SafeConcat(t, sep)
+	local ok, result = pcall(TableConcat, t, sep)
+	return ok and result or nil
+end
+
 -- *** Scanning functions ***
 local function SortByLevelDesc(a, b)
 	return a.level > b.level
@@ -36,7 +44,7 @@ local function ScanStats()
 		-- stat, effectiveStat, posBuff, negBuff = UnitStat("player", statIndex);
 	end
 	t[5] = UnitArmor("player")
-	char.Base = TableConcat(t, "|")
+	char.Base = SafeConcat(t, "|") or char.Base
 	
 	-- *** Melee ***
 	--	"Damage | Speed | Power | Hit rating | Crit chance | Expertise"
@@ -47,7 +55,7 @@ local function ScanStats()
 	t[4] = GetCombatRating(CR_HIT_MELEE)
 	t[5] = format("%.2f", GetCritChance())
 	t[6] = GetExpertise()
-	char.Melee = TableConcat(t, "|")
+	char.Melee = SafeConcat(t, "|") or char.Melee
 	
 	-- *** Ranged ***
 	--	"Damage | Speed | Power | Hit rating | Crit chance"
@@ -59,7 +67,7 @@ local function ScanStats()
 	t[4] = GetCombatRating(CR_HIT_RANGED)
 	t[5] = format("%.2f", GetRangedCritChance())
 	t[6] = nil
-	char.Ranged = TableConcat(t, "|")
+	char.Ranged = SafeConcat(t, "|") or char.Ranged
 	
 	-- *** Spell ***
 	--	"+Damage | +Healing | Hit | Crit chance | Haste | Mana Regen"
@@ -69,7 +77,7 @@ local function ScanStats()
 	t[4] = format("%.2f", GetSpellCritChance(2))
 	t[5] = GetCombatRating(CR_HASTE_SPELL)
 	t[6] = floor(GetManaRegen() * 5.0)
-	char.Spell = TableConcat(t, "|")
+	char.Spell = SafeConcat(t, "|") or char.Spell
 		
 	-- *** Defense ***
 	--	"Armor | Defense | Dodge | Parry | Block | Resilience"
@@ -79,13 +87,13 @@ local function ScanStats()
 	t[4] = format("%.2f", GetParryChance())
 	t[5] = format("%.2f", GetBlockChance())
 	t[6] = GetCombatRating(COMBAT_RATING_RESILIENCE_PLAYER_DAMAGE_TAKEN)
-	char.Defense = TableConcat(t, "|")
+	char.Defense = SafeConcat(t, "|") or char.Defense
 
 	-- *** PVP ***
 	--	"honorable kills | dishonorable kills"
 	wipe(t)
 	t[1], t[2] = GetPVPLifetimeStats()
-	char.PVP = TableConcat(t, "|")
+	char.PVP = SafeConcat(t, "|") or char.PVP
 	
 	-- *** Arena Teams ***
 	--[[

--- a/DataStore_Stats/DataStore_Stats.toc
+++ b/DataStore_Stats/DataStore_Stats.toc
@@ -1,4 +1,4 @@
-## Interface: 120000
+## Interface: 120000, 120005
 ## Title: DataStore_Stats
 ## IconTexture: Interface\Icons\garrison_building_storehouse
 


### PR DESCRIPTION
## Summary
- `ScanStats()` errors out on the very first TableConcat call in WoW 12.0+ because `Unit*` / `Get*` stat APIs can return secret/guarded values that taint `table.concat`'s internal tostring. The AddonFactory callback then aborts and DataStore_Stats stops updating the character record.
- Wrap each `TableConcat(t, ...)` in a pcall'd `SafeConcat` helper. On taint, the field falls back to its previously stored value (degrades gracefully) instead of erroring the whole scan.
- Declare 12.0.5 in toc.

## Repro
On 12.0.x retail:
```
167x DataStore_Stats/DataStore_Stats.lua:39: invalid value (secret) at index 1 in table for 'concat'
[DataStore_Stats/DataStore_Stats.lua]:39: in function 'callback'
[AddonFactory/Core/Addon.lua]:17: in function <AddonFactory/Core/Addon.lua:13>
```

Locals showed `t = { 1=<no value>, 2=<no value>, ... }` — i.e. all 5 entries (UnitStat x4 + UnitArmor) were secret values.

## Test plan
- [ ] Log in on 12.0.5 — no `invalid value (secret)` error from ScanStats.
- [ ] `/dump DataStore:GetCharacterTable("..."):Base` still returns the previously scanned value when the live scan is tainted.
- [ ] Older builds (still listed in toc) continue to scan and store stats normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)